### PR TITLE
Update the-homestead-release.rst

### DIFF
--- a/source/introduction/the-homestead-release.rst
+++ b/source/introduction/the-homestead-release.rst
@@ -20,7 +20,7 @@ While still valid, the substance behind it has changed somewhat.
 The `Olympic testnet <olympic-testnet>`_ phase (before the `Frontier release <history-of-ethereum.html#the-ethereum-frontier-launch>`_) saw a lot of major improvements, followed by Frontier which was launched immediately after. Homestead marks the exit from a beta product to a stable release.
 Homestead is introduced automatically at block number 1,150,000 which should occur roughly around March 14th, 2016, Pi Day.
 
-If you are running a node connected to the live network, it is important that you upgrade to a Homestead-compatible client. Such clients with their versions are listed under :ref:`Ethereum Clients`. Otherwise you will end up on the wrong fork and will no longer be in sync with the rest of the network.
+If you are running a node connected to the live network, it is important that you upgrade to a Homestead-compatible client. Such clients with their versions are listed under "Ethereum Clients>> :ref:`Choosing a client`". Otherwise you will end up on the wrong fork and will no longer be in sync with the rest of the network.
 
 Once the Ethereum blockchain reaches block 1,150,000, the Ethereum network will undergo a hardfork enabling a few major changes such as explained in the following section.
 


### PR DESCRIPTION
`Ethereum Clients` link does not have homestead compatible version number
